### PR TITLE
Update php.ini

### DIFF
--- a/config/php.ini
+++ b/config/php.ini
@@ -10,4 +10,5 @@ track_errors = On
 
 upload_max_filesize = 512M
 post_max_size = 512M
-short_open_tag=off
+short_open_tag = Off
+auto_detect_line_endings = true


### PR DESCRIPTION
We have linux & mac developers and because of that some files when they are saved on mac they have a different end of line character.
This is specially a problem when you use functions like fgetcsv, readfile, file_get_contents, etc.. that they see one line instead of multiples